### PR TITLE
memory fixes

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -1,7 +1,7 @@
 # Compressor Codec
 # ================
 
-struct Bzip2Compressor <: TranscodingStreams.Codec
+mutable struct Bzip2Compressor <: TranscodingStreams.Codec
     stream::BZStream
     blocksize100k::Int
     workfactor::Int

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -1,7 +1,7 @@
 # Decompressor Codec
 # ==================
 
-struct Bzip2Decompressor <: TranscodingStreams.Codec
+mutable struct Bzip2Decompressor <: TranscodingStreams.Codec
     stream::BZStream
     small::Bool
     verbosity::Int

--- a/src/libbzip2.jl
+++ b/src/libbzip2.jl
@@ -21,7 +21,7 @@ mutable struct BZStream
     opaque::Ptr{Cvoid}
 end
 
-bzalloc(::Ptr{Cvoid}, n::Cint) = ccall(:jl_malloc, Ptr{Cvoid}, (Cint,), n)
+bzalloc(::Ptr{Cvoid}, m::Cint, n::Cint) = ccall(:jl_malloc, Ptr{Cvoid}, (Cint,), m*n)
 bzfree(::Ptr{Cvoid}, p::Ptr{Cvoid}) = ccall(:jl_free, Cvoid, (Ptr{Cvoid},), p)
 
 function BZStream()
@@ -29,7 +29,7 @@ function BZStream()
         C_NULL, 0, 0, 0,
         C_NULL, 0, 0, 0,
         C_NULL,
-        @cfunction(bzalloc, Ptr{Cvoid}, (Ptr{Cvoid}, Cint)),
+        @cfunction(bzalloc, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Cint)),
         @cfunction(bzfree, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid})),
         C_NULL,
     )

--- a/src/libbzip2.jl
+++ b/src/libbzip2.jl
@@ -21,12 +21,18 @@ mutable struct BZStream
     opaque::Ptr{Cvoid}
 end
 
+bzalloc(::Ptr{Cvoid}, n::Cint) = ccall(:jl_malloc, Ptr{Cvoid}, (Cint,), n)
+bzfree(::Ptr{Cvoid}, p::Ptr{Cvoid}) = ccall(:jl_free, Cvoid, (Ptr{Cvoid},), p)
+
 function BZStream()
     return BZStream(
         C_NULL, 0, 0, 0,
         C_NULL, 0, 0, 0,
         C_NULL,
-        C_NULL, C_NULL, C_NULL)
+        @cfunction(bzalloc, Ptr{Cvoid}, (Ptr{Cvoid}, Cint)),
+        @cfunction(bzfree, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid})),
+        C_NULL,
+    )
 end
 
 # Action code

--- a/src/libbzip2.jl
+++ b/src/libbzip2.jl
@@ -4,15 +4,15 @@
 const WIN32 = Sys.iswindows() && Sys.WORD_SIZE == 32
 
 mutable struct BZStream
-    next_in::Ptr{UInt8}
-    avail_in::Cint
-    total_in_lo32::Cint
-    total_in_hi32::Cint
+    next_in::Ptr{Cchar}
+    avail_in::Cuint
+    total_in_lo32::Cuint
+    total_in_hi32::Cuint
 
-    next_out::Ptr{UInt8}
-    avail_out::Cint
-    total_out_lo32::Cint
-    total_out_hi32::Cint
+    next_out::Ptr{Cchar}
+    avail_out::Cuint
+    total_out_lo32::Cuint
+    total_out_hi32::Cuint
 
     state::Ptr{Cvoid}
 


### PR DESCRIPTION
The main fix here is to make the Bzip2Compressor and Bz2ipDecompressor types mutable: finalizers don't get called on immutable values—they do not have a canonical memory location.

The other changes is that since Julia doesn't know about memory that libbzip2 allocates directly using `malloc`, it's possible to get into a situation where Julia's GC is hogging all the memory and doesn't know that libbzip2 needs to do a GC to free up some memory for libbzip2. By making libbzip2 hook into Julia's allocation system, we give Julia the chance to free up memory.

Finally, this PR tweaks some of the BZStream struct field types to more accurately match the C types of the libbzip2 library. These changes are unlikely to have any effect, however, since the previously declared types were of the correct size.