### PR TITLE
Update Project.toml to use bzip2 1.0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecBzip2"
 uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.7.2"
+version = "0.8.0"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
@@ -10,7 +10,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-Bzip2_jll = "1.0.6"
+Bzip2_jll = "1.0.8"
 TranscodingStreams = "0.9"
 julia = "1.3"
 


### PR DESCRIPTION
Bzip2 1.0.6 is now 12 years old, whereas 1.0.8 is only 4 years old.

https://gitlab.com/bzip2/bzip2/-/tags