### PR TITLE
`test_roundtrip_seekstart`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,9 @@ import TranscodingStreams
     TranscodingStreams.test_roundtrip_read(Bzip2CompressorStream, Bzip2DecompressorStream)
     TranscodingStreams.test_roundtrip_write(Bzip2CompressorStream, Bzip2DecompressorStream)
     TranscodingStreams.test_roundtrip_lines(Bzip2CompressorStream, Bzip2DecompressorStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(Bzip2CompressorStream, Bzip2DecompressorStream)
+    end
     TranscodingStreams.test_roundtrip_transcode(Bzip2Compressor, Bzip2Decompressor)
 
     @test_throws ArgumentError Bzip2Compressor(blocksize100k=10)


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session.

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/issues/217