### PR TITLE
Bump compat for TranscodingStreams to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecBzip2"
 uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
@@ -11,7 +11,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 Bzip2_jll = "1.0.8"
-TranscodingStreams = "0.9, 0.10"
+TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This update shouldn't affect the public API of this package. TranscodingStreams release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0