### PR TITLE
Update CI, julia compat, and readme links

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,20 +20,29 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
         arch:
-          - x64
+          - default
+          - x86
+        exclude:
+          - os: macos-latest
+            arch: x86
+        include:
+          - os: ubuntu-latest
+            version: 'min'
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+          show-versioninfo: true
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,38 @@
+name: Downstream
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - "BSDiff"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 1
+          arch: x64
+          show-versioninfo: true
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.Registry.update()
+          Pkg.activate(;temp=true)
+          # force it to use this PR's version of the package
+          ENV["JULIA_PKG_DEVDIR"]= mktempdir()
+          Pkg.develop([
+            PackageSpec(path="."),
+            PackageSpec(name="${{ matrix.package }}"),
+          ])
+          Pkg.update()
+          Pkg.test("${{ matrix.package }}")

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+#Mac OS X
+*.DS_Store
+
+#VS Code
+/.vscode/
+
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
 /Manifest.toml
-/deps/build.log
-/deps/deps.jl
-/deps/usr/
+/test/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,4 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 Bzip2_jll = "1.0.8"
 TranscodingStreams = "0.9, 0.10, 0.11"
-julia = "1.3"
+julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CodecBzip2.jl
 
-[![codecov.io][codecov-img]][codecov-url]
+[![CI](https://github.com/JuliaIO/CodecBzip2.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaIO/CodecBzip2.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/JuliaIO/CodecBzip2.jl/graph/badge.svg?token=eToD28jdA7)](https://codecov.io/gh/JuliaIO/CodecBzip2.jl)
 
 ## Installation
 
@@ -43,11 +44,4 @@ This package exports following codecs and streams:
 | `Bzip2Compressor`    | `Bzip2CompressorStream`    |
 | `Bzip2Decompressor`  | `Bzip2DecompressorStream`  |
 
-See docstrings and [TranscodingStreams.jl](https://github.com/bicycle1885/TranscodingStreams.jl) for details.
-
-[travisci-img]: https://travis-ci.org/bicycle1885/CodecBzip2.jl.svg?branch=master
-[travisci-url]: https://travis-ci.org/bicycle1885/CodecBzip2.jl
-[appveyor-img]: https://ci.appveyor.com/api/projects/status/bqm4qh5cd13u70cm?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/bicycle1885/codecbzip2-jl
-[codecov-img]: http://codecov.io/github/bicycle1885/CodecBzip2.jl/coverage.svg?branch=master
-[codecov-url]: http://codecov.io/github/bicycle1885/CodecBzip2.jl?branch=master
+See docstrings and [TranscodingStreams.jl](https://github.com/JuliaIO/TranscodingStreams.jl) for details.


### PR DESCRIPTION
`Bzip2_jll` v1.0.8 requires at least julia 1.6. 