### PR TITLE
Add HDF5 to downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         package:
           - "BSDiff"
+          - "HDF5"
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -76,7 +76,7 @@ function TranscodingStreams.process(codec::Bzip2Decompressor, input::Memory, out
     stream.avail_in = input.size
     stream.next_out = output.ptr
     stream.avail_out = output.size
-    code = decompress!(stream)
+    code = _decompress!(stream)
     Δin = Int(input.size - stream.avail_in)
     Δout = Int(output.size - stream.avail_out)
     if code == BZ_OK

--- a/src/libbzip2.jl
+++ b/src/libbzip2.jl
@@ -161,7 +161,7 @@ function decompress_end!(stream::BZStream)
     end
 end
 
-function decompress!(stream::BZStream)
+function _decompress!(stream::BZStream)
     if WIN32
         return ccall(
             ("BZ2_bzDecompress@4", libbzip2),


### PR DESCRIPTION
HDF5 unfortunately depends on internal CodecBzip2 functions, so regular tests might not catch compatibility issues.