### PR TITLE
Add a finalizer to prevent memory leaks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,4 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 Bzip2_jll = "1.0.8"
 TranscodingStreams = "0.9, 0.10, 0.11"
-julia = "1.6"
+julia = "1.7"

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -1,8 +1,27 @@
 # Compressor Codec
 # ================
 
-mutable struct Bzip2Compressor <: TranscodingStreams.Codec
+mutable struct CompressorContext
+    @atomic is_ready::Bool
     stream::BZStream
+    function CompressorContext()
+        ctx = new(false, BZStream())
+        finalizer(compressor_ctx_finalizer!, ctx)
+    end
+end
+
+function compressor_ctx_finalizer!(ctx::CompressorContext)
+    # The atomic variable is needed because this may be called
+    # with both finalizer and TranscodingStreams.finalize
+    # and TranscodingStreams.finalize might get called in other finalizers
+    if @atomicswap ctx.is_ready = false
+        compress_end!(ctx.stream)
+    end
+    return
+end
+
+struct Bzip2Compressor <: TranscodingStreams.Codec
+    ctx::CompressorContext
     blocksize100k::Int
     workfactor::Int
     verbosity::Int
@@ -37,7 +56,7 @@ function Bzip2Compressor(;blocksize100k::Integer=DEFAULT_BLOCKSIZE100K,
     elseif !(0 ≤ verbosity ≤ 4)
         throw(ArgumentError("verbosity must be within 0..4"))
     end
-    return Bzip2Compressor(BZStream(), blocksize100k, workfactor, verbosity)
+    return Bzip2Compressor(CompressorContext(), blocksize100k, workfactor, verbosity)
 end
 
 const Bzip2CompressorStream{S} = TranscodingStream{Bzip2Compressor,S} where S<:IO
@@ -57,58 +76,54 @@ end
 # -------
 
 function TranscodingStreams.finalize(codec::Bzip2Compressor)
-    if codec.stream.state != C_NULL
-        code = compress_end!(codec.stream)
-        if code != BZ_OK
-            bzerror(code)
-        end
-    end
+    ctx = codec.ctx
+    GC.@preserve ctx compressor_ctx_finalizer!(ctx)
     return
 end
 
 function TranscodingStreams.startproc(codec::Bzip2Compressor, ::Symbol, error_ref::Error)
-    if codec.stream.state != C_NULL
-        code = compress_end!(codec.stream)
-        if code != BZ_OK
-            error_ref[] = BZ2Error(code)
-            return :error
+    ctx = codec.ctx
+    GC.@preserve ctx begin
+        compressor_ctx_finalizer!(ctx)
+        code = compress_init!(ctx.stream, codec.blocksize100k, codec.verbosity, codec.workfactor)
+        # errors in compress_init! do not require clean up, so just throw
+        if code == BZ_OK
+            return :ok
+        elseif code == BZ_CONFIG_ERROR
+            error("BZ_CONFIG_ERROR: libbzip2 has been mis-compiled")
+        elseif code == BZ_PARAM_ERROR
+            error("BZ_PARAM_ERROR: this must be checked in Bzip2Compressor constructor")
+        elseif code == BZ_MEM_ERROR
+            throw(OutOfMemoryError())
+        else
+            error("unexpected libbzip2 error code: $(code)")
         end
-    end
-    code = compress_init!(codec.stream, codec.blocksize100k, codec.verbosity, codec.workfactor)
-    # errors in compress_init! do not require clean up, so just throw
-    if code == BZ_OK
-        return :ok
-    elseif code == BZ_CONFIG_ERROR
-        error("BZ_CONFIG_ERROR: libbzip2 has been mis-compiled")
-    elseif code == BZ_PARAM_ERROR
-        error("BZ_PARAM_ERROR: this must be checked in Bzip2Compressor constructor")
-    elseif code == BZ_MEM_ERROR
-        throw(OutOfMemoryError())
-    else
-        error("unexpected libbzip2 error code: $(code)")
     end
 end
 
 function TranscodingStreams.process(codec::Bzip2Compressor, input::Memory, output::Memory, error_ref::Error)
-    stream = codec.stream
-    if stream.state == C_NULL
-        error("startproc must be called before process")
-    end
-    stream.next_in = input.ptr
-    avail_in = min(input.size, typemax(Cuint))
-    stream.avail_in = avail_in
-    stream.next_out = output.ptr
-    avail_out = min(output.size, typemax(Cuint))
-    stream.avail_out = avail_out
-    code = compress!(stream, input.size > 0 ? BZ_RUN : BZ_FINISH)
-    Δin = Int(avail_in - stream.avail_in)
-    Δout = Int(avail_out - stream.avail_out)
-    if code == BZ_RUN_OK || code == BZ_FINISH_OK
-        return Δin, Δout, :ok
-    elseif code == BZ_STREAM_END
-        return Δin, Δout, :end
-    else
-        error_ref[] = BZ2Error(code)
-        return Δin, Δout, :error
+    ctx = codec.ctx
+    GC.@preserve ctx begin
+        stream = ctx.stream
+        if stream.state == C_NULL
+            error("startproc must be called before process")
+        end
+        stream.next_in = input.ptr
+        avail_in = min(input.size, typemax(Cuint))
+        stream.avail_in = avail_in
+        stream.next_out = output.ptr
+        avail_out = min(output.size, typemax(Cuint))
+        stream.avail_out = avail_out
+        code = compress!(stream, input.size > 0 ? BZ_RUN : BZ_FINISH)
+        Δin = Int(avail_in - stream.avail_in)
+        Δout = Int(avail_out - stream.avail_out)
+        if code == BZ_RUN_OK || code == BZ_FINISH_OK
+            return Δin, Δout, :ok
+        elseif code == BZ_STREAM_END
+            return Δin, Δout, :end
+        else
+            error_ref[] = BZ2Error(code)
+            return Δin, Δout, :error
+        end
     end
 end

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -14,7 +14,7 @@ function compressor_ctx_finalizer!(ctx::CompressorContext)
     # The atomic variable is needed because this may be called
     # with both finalizer and TranscodingStreams.finalize
     # and TranscodingStreams.finalize might get called in other finalizers
-    if @atomicswap ctx.is_ready = false
+    if @atomicswap(ctx.is_ready = false)
         compress_end!(ctx.stream)
     end
     return
@@ -85,6 +85,7 @@ function TranscodingStreams.startproc(codec::Bzip2Compressor, ::Symbol, error_re
     ctx = codec.ctx
     GC.@preserve ctx begin
         compressor_ctx_finalizer!(ctx)
+        @atomic ctx.is_ready = true
         code = compress_init!(ctx.stream, codec.blocksize100k, codec.verbosity, codec.workfactor)
         # errors in compress_init! do not require clean up, so just throw
         if code == BZ_OK

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -1,8 +1,27 @@
 # Decompressor Codec
 # ==================
 
-mutable struct Bzip2Decompressor <: TranscodingStreams.Codec
+mutable struct DecompressorContext
+    @atomic is_ready::Bool
     stream::BZStream
+    function DecompressorContext()
+        ctx = new(false, BZStream())
+        finalizer(decompressor_ctx_finalizer!, ctx)
+    end
+end
+
+function decompressor_ctx_finalizer!(ctx::DecompressorContext)
+    # The atomic variable is needed because this may be called
+    # with both finalizer and TranscodingStreams.finalize
+    # and TranscodingStreams.finalize might get called in other finalizers
+    if @atomicswap ctx.is_ready = false
+        decompress_end!(ctx.stream)
+    end
+    return
+end
+
+mutable struct Bzip2Decompressor <: TranscodingStreams.Codec
+    ctx::DecompressorContext
     small::Bool
     verbosity::Int
 end
@@ -25,7 +44,7 @@ function Bzip2Decompressor(;small::Bool=false, verbosity::Integer=DEFAULT_VERBOS
     if !(0 ≤ verbosity ≤ 4)
         throw(ArgumentError("verbosity must be within 0..4"))
     end
-    return Bzip2Decompressor(BZStream(), small, verbosity)
+    return Bzip2Decompressor(DecompressorContext(), small, verbosity)
 end
 
 const Bzip2DecompressorStream{S} = TranscodingStream{Bzip2Decompressor,S} where S<:IO
@@ -45,65 +64,61 @@ end
 # -------
 
 function TranscodingStreams.finalize(codec::Bzip2Decompressor)
-    if codec.stream.state != C_NULL
-        code = decompress_end!(codec.stream)
-        if code != BZ_OK
-            bzerror(code)
-        end
-    end
+    ctx = codec.ctx
+    GC.@preserve ctx decompressor_ctx_finalizer!(ctx)
     return
 end
 
 function TranscodingStreams.startproc(codec::Bzip2Decompressor, ::Symbol, error_ref::Error)
-    if codec.stream.state != C_NULL
-        code = decompress_end!(codec.stream)
-        if code != BZ_OK
-            error_ref[] = BZ2Error(code)
-            return :error
+    ctx = codec.ctx
+    GC.@preserve ctx begin
+        decompressor_ctx_finalizer!(ctx)
+        code = decompress_init!(ctx.stream, codec.verbosity, codec.small)
+        # errors in decompress_init! do not require clean up, so just throw
+        if code == BZ_OK
+            return :ok
+        elseif code == BZ_CONFIG_ERROR
+            error("BZ_CONFIG_ERROR: libbzip2 has been mis-compiled")
+        elseif code == BZ_PARAM_ERROR
+            error("BZ_PARAM_ERROR: this must be checked in Bzip2Decompressor constructor")
+        elseif code == BZ_MEM_ERROR
+            throw(OutOfMemoryError())
+        else
+            error("unexpected libbzip2 error code: $(code)")
         end
-    end
-    code = decompress_init!(codec.stream, codec.verbosity, codec.small)
-    # errors in decompress_init! do not require clean up, so just throw
-    if code == BZ_OK
-        return :ok
-    elseif code == BZ_CONFIG_ERROR
-        error("BZ_CONFIG_ERROR: libbzip2 has been mis-compiled")
-    elseif code == BZ_PARAM_ERROR
-        error("BZ_PARAM_ERROR: this must be checked in Bzip2Decompressor constructor")
-    elseif code == BZ_MEM_ERROR
-        throw(OutOfMemoryError())
-    else
-        error("unexpected libbzip2 error code: $(code)")
     end
 end
 
 function TranscodingStreams.process(codec::Bzip2Decompressor, input::Memory, output::Memory, error_ref::Error)
-    stream = codec.stream
-    if stream.state == C_NULL
-        error("startproc must be called before process")
-    end
-    stream.next_in = input.ptr
-    avail_in = min(input.size, typemax(Cuint))
-    stream.avail_in = avail_in
-    stream.next_out = output.ptr
-    avail_out = min(output.size, typemax(Cuint))
-    stream.avail_out = avail_out
-    code = decompress!(stream)
-    Δin = Int(avail_in - stream.avail_in)
-    Δout = Int(avail_out - stream.avail_out)
-    if code == BZ_OK
-        if iszero(input.size) && !iszero(stream.avail_out)
-            error_ref[] = BZ2Error(BZ_UNEXPECTED_EOF)
-            return Δin, Δout, :error
-        else
-            return Δin, Δout, :ok
+    ctx = codec.ctx
+    GC.@preserve ctx begin
+        stream = ctx.stream
+        if stream.state == C_NULL
+            error("startproc must be called before process")
         end
-    elseif code == BZ_STREAM_END
-        return Δin, Δout, :end
-    elseif code == BZ_MEM_ERROR
-        throw(OutOfMemoryError())
-    else
-        error_ref[] = BZ2Error(code)
-        return Δin, Δout, :error
+        stream.next_in = input.ptr
+        avail_in = min(input.size, typemax(Cuint))
+        stream.avail_in = avail_in
+        stream.next_out = output.ptr
+        avail_out = min(output.size, typemax(Cuint))
+        stream.avail_out = avail_out
+        code = decompress!(stream)
+        Δin = Int(avail_in - stream.avail_in)
+        Δout = Int(avail_out - stream.avail_out)
+        if code == BZ_OK
+            if iszero(input.size) && !iszero(stream.avail_out)
+                error_ref[] = BZ2Error(BZ_UNEXPECTED_EOF)
+                return Δin, Δout, :error
+            else
+                return Δin, Δout, :ok
+            end
+        elseif code == BZ_STREAM_END
+            return Δin, Δout, :end
+        elseif code == BZ_MEM_ERROR
+            throw(OutOfMemoryError())
+        else
+            error_ref[] = BZ2Error(code)
+            return Δin, Δout, :error
+        end
     end
 end

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -14,7 +14,7 @@ function decompressor_ctx_finalizer!(ctx::DecompressorContext)
     # The atomic variable is needed because this may be called
     # with both finalizer and TranscodingStreams.finalize
     # and TranscodingStreams.finalize might get called in other finalizers
-    if @atomicswap ctx.is_ready = false
+    if @atomicswap(ctx.is_ready = false)
         decompress_end!(ctx.stream)
     end
     return
@@ -73,6 +73,7 @@ function TranscodingStreams.startproc(codec::Bzip2Decompressor, ::Symbol, error_
     ctx = codec.ctx
     GC.@preserve ctx begin
         decompressor_ctx_finalizer!(ctx)
+        @atomic ctx.is_ready = true
         code = decompress_init!(ctx.stream, codec.verbosity, codec.small)
         # errors in decompress_init! do not require clean up, so just throw
         if code == BZ_OK

--- a/test/big-mem-tests.jl
+++ b/test/big-mem-tests.jl
@@ -6,6 +6,16 @@
 using Test
 using CodecBzip2
 
+@testset "memory leak" begin
+    function foo()
+        for i in 1:1000000
+            c = transcode(Bzip2Compressor(), zeros(UInt8,16))
+            u = transcode(Bzip2Decompressor(), c)
+        end
+    end
+    foo()
+end
+
 @testset "Big Memory Tests" begin
     Sys.WORD_SIZE == 64 || error("tests require 64 bit word size")
     @info "compressing zeros"


### PR DESCRIPTION
Fixes #27 

This PR uses atomic operations to prevent multiple finalizers from freeing the same stream concurrently.

This requires julia 1.7