### PR TITLE
Add finalizer to BZStream and make `TranscodingStreams.finalize` a noop

### DIFF
--- a/src/libbzip2.jl
+++ b/src/libbzip2.jl
@@ -106,6 +106,11 @@ function compress_end!(stream::BZStream)
     end
 end
 
+function compress_finalizer!(stream::BZStream)
+    compress_end!(stream)
+    nothing
+end
+
 function compress!(stream::BZStream, action::Integer)
     if WIN32
         return ccall(
@@ -159,6 +164,11 @@ function decompress_end!(stream::BZStream)
             (Ref{BZStream},),
             stream)
     end
+end
+
+function decompress_finalizer!(stream::BZStream)
+    decompress_end!(stream)
+    nothing
 end
 
 function decompress!(stream::BZStream)

--- a/test/big-mem-tests.jl
+++ b/test/big-mem-tests.jl
@@ -6,6 +6,16 @@
 using Test
 using CodecBzip2
 
+@testset "memory leak" begin
+    function foo()
+        for i in 1:1000000
+            c = transcode(Bzip2Compressor(), zeros(UInt8,16))
+            u = transcode(Bzip2Decompressor(), c)
+        end
+    end
+    foo()
+end
+
 @testset "Big Memory Tests" begin
     Sys.WORD_SIZE == 64 || error("tests require 64 bit word size")
     @info "compressing zeros"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,11 @@ Aqua.test_all(CodecBzip2)
         @test sprint(Base.showerror, CodecBzip2.BZ2Error(-100)) ==
             "BZ2Error: unknown bzip2 error code: -100"
     end
+    @testset "memory leaks" begin
+        # issue #27
+        for i in 1:200000
+            c = transcode(Bzip2Compressor(), zeros(UInt8,16))
+            u = transcode(Bzip2Decompressor(), c)
+        end
+    end
 end


### PR DESCRIPTION
Arguably simpler alternative to #42 

According to the bzip2 manual, "The low-level part of the library has no global variables and is therefore thread-safe."
So there shouldn't be a need for anything fancy here.

Also fixes #27 