### PR TITLE
Bump version to 0.8.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "CodecBzip2"
 uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 Bzip2_jll = "6e34b625-4abd-537c-b88f-471c36dfa7a0"


### PR DESCRIPTION
diff: https://github.com/JuliaIO/CodecBzip2.jl/compare/v0.8.4...b78796864b0f55946feab511b0bb4e339a39ce2d

This release bumps julia compat to v1.6.

This release also fixes #27 #32 #35 and #36

Error printing is also improved. Memory allocation errors throw `OutOfMemoryError` and other errors have error messages now.

I plan on releasing this sometime next week unless there are any issues.